### PR TITLE
Refactoring - All AutoWired annotations replaced with constructor injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/ecommerce/project/controller/AddressController.java
+++ b/src/main/java/com/ecommerce/project/controller/AddressController.java
@@ -7,7 +7,6 @@ import com.ecommerce.project.payload.AddressDTO;
 import com.ecommerce.project.payload.AddressResponse;
 import com.ecommerce.project.security.service.AuthUtil;
 import com.ecommerce.project.service.AddressService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,11 +15,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class AddressController {
 
-    @Autowired
-    AuthUtil authUtil;
+    private final AuthUtil authUtil;
+    private final AddressService addressService;
 
-    @Autowired
-    AddressService addressService;
+    public AddressController(AuthUtil authUtil, AddressService addressService) {
+        this.authUtil = authUtil;
+        this.addressService = addressService;
+    }
 
     @PostMapping("/addresses")
     public ResponseEntity<AddressDTO> createAddress(@RequestBody AddressDTO addressDTO) {

--- a/src/main/java/com/ecommerce/project/controller/AuthController.java
+++ b/src/main/java/com/ecommerce/project/controller/AuthController.java
@@ -13,7 +13,6 @@ import com.ecommerce.project.security.response.MessageResponse;
 import com.ecommerce.project.security.response.UserInfoResponse;
 import com.ecommerce.project.security.service.UserDetailsImpl;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -37,20 +36,22 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    @Autowired
-    private JwtUtils jwtUtils;
+    private final JwtUtils jwtUtils;
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private AuthenticationManager authenticationManager;
+    public AuthController(JwtUtils jwtUtils, AuthenticationManager authenticationManager,
+                          UserRepository userRepository, RoleRepository roleRepository,
+                          PasswordEncoder passwordEncoder) {
+        this.jwtUtils = jwtUtils;
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
-    @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    RoleRepository roleRepository;
-
-    @Autowired
-    PasswordEncoder passwordEncoder;
 
     /**
      * Authenticates a user based on the provided login request.

--- a/src/main/java/com/ecommerce/project/controller/CartController.java
+++ b/src/main/java/com/ecommerce/project/controller/CartController.java
@@ -2,8 +2,6 @@ package com.ecommerce.project.controller;
 
 import com.ecommerce.project.payload.CartDTO;
 import com.ecommerce.project.service.CartService;
-import org.apache.coyote.Response;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,8 +12,11 @@ import java.util.List;
 @RequestMapping("/api")
 public class CartController {
 
-    @Autowired
-    private CartService cartService;
+    private final CartService cartService;
+
+    public CartController(CartService cartService) {
+        this.cartService = cartService;
+    }
 
     @PostMapping("/carts/products/{productId}/quantity/{quantity}")
     public ResponseEntity<CartDTO> addProductToCart(@PathVariable Long productId,

--- a/src/main/java/com/ecommerce/project/controller/OrderController.java
+++ b/src/main/java/com/ecommerce/project/controller/OrderController.java
@@ -5,7 +5,6 @@ import com.ecommerce.project.payload.OrderDTO;
 import com.ecommerce.project.payload.OrderRequestDTO;
 import com.ecommerce.project.security.service.AuthUtil;
 import com.ecommerce.project.service.OrderService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,11 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class OrderController {
 
-    @Autowired
-    private OrderService orderService;
+    private final OrderService orderService;
+    private final AuthUtil authUtil;
 
-    @Autowired
-    private AuthUtil authUtil;
+    public OrderController(OrderService orderService, AuthUtil authUtil) {
+        this.orderService = orderService;
+        this.authUtil = authUtil;
+    }
 
     @PostMapping("/users/order")
     public ResponseEntity<OrderDTO> orderProducts(@RequestBody OrderRequestDTO orderRequestDTO) {

--- a/src/main/java/com/ecommerce/project/repositories/CartItemRepository.java
+++ b/src/main/java/com/ecommerce/project/repositories/CartItemRepository.java
@@ -3,7 +3,9 @@ package com.ecommerce.project.repositories;
 import com.ecommerce.project.model.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     @Query("SELECT ci FROM CartItem ci WHERE ci.cart.id = ?1 AND ci.product.id = ?2")
     CartItem findCartItemByProductIdAndCartId(Long cartId, Long productId);

--- a/src/main/java/com/ecommerce/project/repositories/CartRepository.java
+++ b/src/main/java/com/ecommerce/project/repositories/CartRepository.java
@@ -3,9 +3,11 @@ package com.ecommerce.project.repositories;
 import com.ecommerce.project.model.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("SELECT c FROM Cart c WHERE c.user.email = ?1")
     Cart findCartByEmail(String email);

--- a/src/main/java/com/ecommerce/project/repositories/RoleRepository.java
+++ b/src/main/java/com/ecommerce/project/repositories/RoleRepository.java
@@ -3,9 +3,11 @@ package com.ecommerce.project.repositories;
 import com.ecommerce.project.model.AppRole;
 import com.ecommerce.project.model.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface RoleRepository extends JpaRepository<Role, Integer> {
 
     Optional<Role> findByRoleName(AppRole appRole);

--- a/src/main/java/com/ecommerce/project/repositories/UserRepository.java
+++ b/src/main/java/com/ecommerce/project/repositories/UserRepository.java
@@ -6,8 +6,11 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 

--- a/src/main/java/com/ecommerce/project/security/jwt/AuthTokenFilter.java
+++ b/src/main/java/com/ecommerce/project/security/jwt/AuthTokenFilter.java
@@ -25,13 +25,16 @@ import java.io.IOException;
  */
 @Component
 public class AuthTokenFilter extends OncePerRequestFilter {
-    @Autowired
-    private JwtUtils jwtUtils;
 
-    @Autowired
-    private UserDetailsServiceImpl userDetailsService;
+    private final JwtUtils jwtUtils;
+    private final UserDetailsServiceImpl userDetailsService;
 
     private static final Logger logger = LoggerFactory.getLogger(AuthTokenFilter.class);
+
+    public AuthTokenFilter(JwtUtils jwtUtils, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtils = jwtUtils;
+        this.userDetailsService = userDetailsService;
+    }
 
     /**
      * Processes incoming HTTP requests to authenticate users based on the presence

--- a/src/main/java/com/ecommerce/project/security/service/AuthUtil.java
+++ b/src/main/java/com/ecommerce/project/security/service/AuthUtil.java
@@ -21,8 +21,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class AuthUtil {
 
-    @Autowired
-    UserRepository userRepository;
+    private final UserRepository userRepository;
+
+    public AuthUtil(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     public String loggedInEmail() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/ecommerce/project/service/AddressServiceImpl.java
+++ b/src/main/java/com/ecommerce/project/service/AddressServiceImpl.java
@@ -19,11 +19,14 @@ import java.util.List;
 @Service
 public class AddressServiceImpl implements AddressService {
 
-    @Autowired
-    ModelMapper modelMapper;
 
-    @Autowired
-    AddressRepository addressRepository;
+    private final ModelMapper modelMapper;
+    private final AddressRepository addressRepository;
+
+    public AddressServiceImpl(ModelMapper modelMapper, AddressRepository addressRepository) {
+        this.modelMapper = modelMapper;
+        this.addressRepository = addressRepository;
+    }
 
     @Override
     public AddressDTO createAddress(AddressDTO addressDTO, User user) {

--- a/src/main/java/com/ecommerce/project/service/CartServiceImpl.java
+++ b/src/main/java/com/ecommerce/project/service/CartServiceImpl.java
@@ -21,20 +21,21 @@ import java.util.List;
 @Service
 public class CartServiceImpl implements CartService {
 
-    @Autowired
-    private CartRepository cartRepository;
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ModelMapper modelMapper;
+    private final AuthUtil authUtil;
 
-    @Autowired
-    private ProductRepository productRepository;
+    public CartServiceImpl(CartRepository cartRepository, ProductRepository productRepository,
+                           CartItemRepository cartItemRepository, ModelMapper modelMapper, AuthUtil authUtil) {
+        this.cartRepository = cartRepository;
+        this.productRepository = productRepository;
+        this.cartItemRepository = cartItemRepository;
+        this.modelMapper = modelMapper;
+        this.authUtil = authUtil;
+    }
 
-    @Autowired
-    private CartItemRepository cartItemRepository;
-
-    @Autowired
-    private ModelMapper modelMapper;
-
-    @Autowired
-    private AuthUtil authUtil;
 
     @Override
     public CartDTO addProductToCart(Long productId, Integer quantity) {

--- a/src/main/java/com/ecommerce/project/service/OrderServiceImpl.java
+++ b/src/main/java/com/ecommerce/project/service/OrderServiceImpl.java
@@ -16,29 +16,28 @@ import java.util.List;
 @Service
 public class OrderServiceImpl implements OrderService {
 
-    @Autowired
-    CartRepository cartRepository;
+    private final CartRepository cartRepository;
+    private final AddressRepository addressRepository;
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductRepository productRepository;
+    private final CartService cartService;
+    private final ModelMapper modelMapper;
 
-    @Autowired
-    AddressRepository addressRepository;
-
-    @Autowired
-    PaymentRepository paymentRepository;
-
-    @Autowired
-    OrderRepository orderRepository;
-
-    @Autowired
-    OrderItemRepository orderItemRepository;
-
-    @Autowired
-    ProductRepository productRepository;
-
-    @Autowired
-    CartService cartService;
-
-    @Autowired
-    ModelMapper modelMapper;
+    public OrderServiceImpl(CartRepository cartRepository, AddressRepository addressRepository,
+                            PaymentRepository paymentRepository, OrderRepository orderRepository,
+                            OrderItemRepository orderItemRepository, ProductRepository productRepository,
+                            CartService cartService, ModelMapper modelMapper) {
+        this.cartRepository = cartRepository;
+        this.addressRepository = addressRepository;
+        this.paymentRepository = paymentRepository;
+        this.orderRepository = orderRepository;
+        this.orderItemRepository = orderItemRepository;
+        this.productRepository = productRepository;
+        this.cartService = cartService;
+        this.modelMapper = modelMapper;
+    }
 
     @Transactional
     @Override


### PR DESCRIPTION
The instructor for the Udemy course I was taking overused Autowired. I learned elsewhere that constructor injection is preferable for many reasons, including:

Immutablity - Can declare fields as private final, signaling that they should not be changed at any point Safety - Eliminates risk of null dependencies

I used constructor injection at some points in the application previously just for practice, but knowing now that constructor injection is FAR preferable, I went back and refactored the entire application to use constructor injection.